### PR TITLE
Generate a minimum recommended length default DJANGO_SECRET_KEY

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -5,7 +5,7 @@ CONSUMER_KEY=
 CONSUMER_SECRET=
 
 ## Generate a secret key with:
-##      `python3 -c "import secrets; print(secrets.token_urlsafe())"`
+##      `python3 -c "import secrets; print(secrets.token_urlsafe(50))"`
 ## ...and put it here.
 DJANGO_SECRET_KEY=
 

--- a/secateur/settings.py
+++ b/secateur/settings.py
@@ -23,7 +23,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # See https://docs.djangoproject.com/en/2.0/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.environ.get("DJANGO_SECRET_KEY", secrets.token_urlsafe(30))
+SECRET_KEY = os.environ.get("DJANGO_SECRET_KEY", secrets.token_urlsafe(50))
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.environ.get("DEBUG", "false").lower() == "true"


### PR DESCRIPTION
As of now in django core, the recommended minimum secret key length is 50, when using `./manage.py check --deploy` ([variable](https://github.com/django/django/blob/c5075360c50b6e681fb3e7d58e6e93ae96662f49/django/core/checks/security/base.py#L5), [code](https://github.com/django/django/blob/c5075360c50b6e681fb3e7d58e6e93ae96662f49/django/core/checks/security/base.py#L63))

To ensure this is communicated as simply as possible, I've provided a value to `token_urlsafe`

https://docs.python.org/3/library/secrets.html#secrets.token_urlsafe
> The text is Base64 encoded, so on average each byte results in approximately 1.3 characters

So this'll be longer than 50, but that's fine. It'll always be at *least* 50. 