### PR TITLE
fix: Correct typo in base.html.

### DIFF
--- a/secateur/templates/base.html
+++ b/secateur/templates/base.html
@@ -6,7 +6,7 @@
 {% block bootstrap4_content %}
   <header>
     <nav class="navbar navbar-expand navbar-light bg-light">
-      <a class="navbar-brand" href="{% url "home" %}"}">Secateur</a>
+      <a class="navbar-brand" href="{% url "home" %}">Secateur</a>
       <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarText" aria-controls="navbarText" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>


### PR DESCRIPTION
Double-up of closing tags caused a link to render with an extra nonsensical attribute:
`<a class="navbar-brand" href="/" }"="">Secateur</a>`