### PR TITLE
feat: Allow writing metrics to console while also sending to OTLP for debug.

### DIFF
--- a/secateur/otel.py
+++ b/secateur/otel.py
@@ -62,19 +62,22 @@ class DeltaOTLPMetricExporter(
         return opentelemetry.sdk._metrics.point.AggregationTemporality.DELTA
 
 
-if os.environ.get("METRICS_EXPORT_ENDPOINT"):
-    metric_exporter = DeltaOTLPMetricExporter(
-        endpoint=os.environ.get("METRICS_EXPORT_ENDPOINT"),
+metric_exporters = []
+metric_exporter_endpoint = os.environ.get("METRICS_EXPORT_ENDPOINT")
+if metric_exporter_endpoint:
+    metric_exporters.append(
+        DeltaOTLPMetricExporter(
+            endpoint=metric_exporter_endpoint,
+        )
     )
-else:
-    metric_exporter = DeltaConsoleMetricExporter()
+if os.environ.get("METRICS_EXPORT_CONSOLE") or not metric_exporter_endpoint:
+    metric_exporters.append(DeltaConsoleMetricExporter())
 
 opentelemetry._metrics.set_meter_provider(
     opentelemetry.sdk._metrics.MeterProvider(
         metric_readers=[
-            opentelemetry.sdk._metrics.export.PeriodicExportingMetricReader(
-                metric_exporter
-            ),
+            opentelemetry.sdk._metrics.export.PeriodicExportingMetricReader(exporter)
+            for exporter in metric_exporters
         ]
     )
 )

--- a/secateur/otel.py
+++ b/secateur/otel.py
@@ -62,22 +62,22 @@ class DeltaOTLPMetricExporter(
         return opentelemetry.sdk._metrics.point.AggregationTemporality.DELTA
 
 
-metric_exporters = []
-metric_exporter_endpoint = os.environ.get("METRICS_EXPORT_ENDPOINT")
-if metric_exporter_endpoint:
-    metric_exporters.append(
+_metric_exporters = []
+_metric_exporter_endpoint = os.environ.get("METRICS_EXPORT_ENDPOINT")
+if _metric_exporter_endpoint:
+    _metric_exporters.append(
         DeltaOTLPMetricExporter(
             endpoint=metric_exporter_endpoint,
         )
     )
-if os.environ.get("METRICS_EXPORT_CONSOLE") or not metric_exporter_endpoint:
-    metric_exporters.append(DeltaConsoleMetricExporter())
+if os.environ.get("METRICS_EXPORT_CONSOLE") or not _metric_exporter_endpoint:
+    _metric_exporters.append(DeltaConsoleMetricExporter())
 
 opentelemetry._metrics.set_meter_provider(
     opentelemetry.sdk._metrics.MeterProvider(
         metric_readers=[
             opentelemetry.sdk._metrics.export.PeriodicExportingMetricReader(exporter)
-            for exporter in metric_exporters
+            for exporter in _metric_exporters
         ]
     )
 )

--- a/secateur/otel.py
+++ b/secateur/otel.py
@@ -67,7 +67,7 @@ _metric_exporter_endpoint = os.environ.get("METRICS_EXPORT_ENDPOINT")
 if _metric_exporter_endpoint:
     _metric_exporters.append(
         DeltaOTLPMetricExporter(
-            endpoint=metric_exporter_endpoint,
+            endpoint=_metric_exporter_endpoint,
         )
     )
 if os.environ.get("METRICS_EXPORT_CONSOLE") or not _metric_exporter_endpoint:


### PR DESCRIPTION
Currently, when METRICS_EXPORT_ENDPOINT is set, the write of metrics to the console is disabled. I wanted to be able to have the metrics written to the console as well, to aid in debugging the connection to my OTLP collector.

This PR preserves the existing behaviour by default, but adds an existing variable METRICS_EXPORT_CONSOLE, which will cause metrics to be written to the console when set and truthy.