### PR TITLE
fix: Redirect when visiting /disconnected/ while logged in.

### DIFF
--- a/secateur/tests/test_views.py
+++ b/secateur/tests/test_views.py
@@ -7,9 +7,9 @@ class TestHome(TestCase):
     def test_home(self) -> None:
         r = self.client.get("/")
         assert r.status_code == 200
-        self.assertTemplateUsed(r, 'home.html')
-        self.assertTemplateUsed(r, 'base.html')
-        self.assertTemplateUsed(r, 'bootstrap.html')
+        self.assertTemplateUsed(r, "home.html")
+        self.assertTemplateUsed(r, "base.html")
+        self.assertTemplateUsed(r, "bootstrap.html")
 
     @override_settings(
         CACHES={"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
@@ -19,9 +19,9 @@ class TestHome(TestCase):
         self.client.force_login(u)
         r = self.client.get("/")
         assert r.status_code == 200
-        self.assertTemplateUsed(r, 'home.html')
-        self.assertTemplateUsed(r, 'base.html')
-        self.assertTemplateUsed(r, 'bootstrap.html')
+        self.assertTemplateUsed(r, "home.html")
+        self.assertTemplateUsed(r, "base.html")
+        self.assertTemplateUsed(r, "bootstrap.html")
 
 
 class TestAdmin(TestCase):
@@ -30,9 +30,9 @@ class TestAdmin(TestCase):
         self.assertRedirects(
             r, "/admin/login/?next=/admin/", fetch_redirect_response=False
         )
-        self.assertTemplateNotUsed(r, 'admin/index.html')
-        self.assertTemplateNotUsed(r, 'admin/base_site.html')
-        self.assertTemplateNotUsed(r, 'admin/base.html')
+        self.assertTemplateNotUsed(r, "admin/index.html")
+        self.assertTemplateNotUsed(r, "admin/base_site.html")
+        self.assertTemplateNotUsed(r, "admin/base.html")
 
     @override_settings(
         CACHES={"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
@@ -42,9 +42,9 @@ class TestAdmin(TestCase):
         self.assertRedirects(
             r, "/admin/login/?next=/admin/", fetch_redirect_response=False
         )
-        self.assertTemplateNotUsed(r, 'admin/index.html')
-        self.assertTemplateNotUsed(r, 'admin/base_site.html')
-        self.assertTemplateNotUsed(r, 'admin/base.html')
+        self.assertTemplateNotUsed(r, "admin/index.html")
+        self.assertTemplateNotUsed(r, "admin/base_site.html")
+        self.assertTemplateNotUsed(r, "admin/base.html")
 
     @override_settings(
         CACHES={"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
@@ -56,9 +56,9 @@ class TestAdmin(TestCase):
         self.client.force_login(u)
         r = self.client.get("/admin/")
         assert r.status_code == 200
-        self.assertTemplateUsed(r, 'admin/index.html')
-        self.assertTemplateUsed(r, 'admin/base_site.html')
-        self.assertTemplateUsed(r, 'admin/base.html')
+        self.assertTemplateUsed(r, "admin/index.html")
+        self.assertTemplateUsed(r, "admin/base_site.html")
+        self.assertTemplateUsed(r, "admin/base.html")
 
 
 class TestBlock(TestCase):
@@ -67,9 +67,9 @@ class TestBlock(TestCase):
         self.assertRedirects(
             r, "/login/twitter/?next=/block/", fetch_redirect_response=False
         )
-        self.assertTemplateNotUsed(r, 'block.html')
-        self.assertTemplateNotUsed(r, 'base.html')
-        self.assertTemplateNotUsed(r, 'bootstrap.html')
+        self.assertTemplateNotUsed(r, "block.html")
+        self.assertTemplateNotUsed(r, "base.html")
+        self.assertTemplateNotUsed(r, "bootstrap.html")
 
     @override_settings(
         CACHES={"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
@@ -79,9 +79,9 @@ class TestBlock(TestCase):
         self.client.force_login(u)
         r = self.client.get("/block/")
         assert r.status_code == 200
-        self.assertTemplateUsed(r, 'block.html')
-        self.assertTemplateUsed(r, 'base.html')
-        self.assertTemplateUsed(r, 'bootstrap.html')
+        self.assertTemplateUsed(r, "block.html")
+        self.assertTemplateUsed(r, "base.html")
+        self.assertTemplateUsed(r, "bootstrap.html")
 
 
 @override_settings(
@@ -93,18 +93,18 @@ class TestBlocked(TestCase):
         self.assertRedirects(
             r, "/login/twitter/?next=/blocked/", fetch_redirect_response=False
         )
-        self.assertTemplateNotUsed(r, 'blocked.html')
-        self.assertTemplateNotUsed(r, 'base.html')
-        self.assertTemplateNotUsed(r, 'bootstrap.html')
+        self.assertTemplateNotUsed(r, "blocked.html")
+        self.assertTemplateNotUsed(r, "base.html")
+        self.assertTemplateNotUsed(r, "bootstrap.html")
 
     def test_blocked_with_user(self) -> None:
         u = _test_user()
         self.client.force_login(u)
         r = self.client.get("/blocked/")
         assert r.status_code == 200
-        self.assertTemplateUsed(r, 'blocked.html')
-        self.assertTemplateUsed(r, 'base.html')
-        self.assertTemplateUsed(r, 'bootstrap.html')
+        self.assertTemplateUsed(r, "blocked.html")
+        self.assertTemplateUsed(r, "base.html")
+        self.assertTemplateUsed(r, "bootstrap.html")
 
 
 @override_settings(
@@ -118,18 +118,18 @@ class TestUnblockEverybody(TestCase):
             "/login/twitter/?next=/unblock-everybody/",
             fetch_redirect_response=False,
         )
-        self.assertTemplateNotUsed(r, 'unblock-everybody.html')
-        self.assertTemplateNotUsed(r, 'base.html')
-        self.assertTemplateNotUsed(r, 'bootstrap.html')
+        self.assertTemplateNotUsed(r, "unblock-everybody.html")
+        self.assertTemplateNotUsed(r, "base.html")
+        self.assertTemplateNotUsed(r, "bootstrap.html")
 
     def test_unblock_everybody_with_user(self) -> None:
         u = _test_user()
         self.client.force_login(u)
         r = self.client.get("/unblock-everybody/")
         assert r.status_code == 200
-        self.assertTemplateUsed(r, 'unblock-everybody.html')
-        self.assertTemplateUsed(r, 'base.html')
-        self.assertTemplateUsed(r, 'bootstrap.html')
+        self.assertTemplateUsed(r, "unblock-everybody.html")
+        self.assertTemplateUsed(r, "base.html")
+        self.assertTemplateUsed(r, "bootstrap.html")
 
 
 class TestSearch(TestCase):
@@ -138,9 +138,9 @@ class TestSearch(TestCase):
         self.assertRedirects(
             r, "/login/twitter/?next=/search/", fetch_redirect_response=False
         )
-        self.assertTemplateNotUsed(r, 'search.html')
-        self.assertTemplateNotUsed(r, 'base.html')
-        self.assertTemplateNotUsed(r, 'bootstrap.html')
+        self.assertTemplateNotUsed(r, "search.html")
+        self.assertTemplateNotUsed(r, "base.html")
+        self.assertTemplateNotUsed(r, "bootstrap.html")
 
     @override_settings(
         CACHES={"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
@@ -150,9 +150,9 @@ class TestSearch(TestCase):
         self.client.force_login(u)
         r = self.client.get("/search/")
         assert r.status_code == 200
-        self.assertTemplateUsed(r, 'search.html')
-        self.assertTemplateUsed(r, 'base.html')
-        self.assertTemplateUsed(r, 'bootstrap.html')
+        self.assertTemplateUsed(r, "search.html")
+        self.assertTemplateUsed(r, "base.html")
+        self.assertTemplateUsed(r, "bootstrap.html")
 
 
 class TestLogMessages(TestCase):
@@ -161,9 +161,9 @@ class TestLogMessages(TestCase):
         self.assertRedirects(
             r, "/login/twitter/?next=/log-messages/", fetch_redirect_response=False
         )
-        self.assertTemplateNotUsed(r, 'log-messages.html')
-        self.assertTemplateNotUsed(r, 'base.html')
-        self.assertTemplateNotUsed(r, 'bootstrap.html')
+        self.assertTemplateNotUsed(r, "log-messages.html")
+        self.assertTemplateNotUsed(r, "base.html")
+        self.assertTemplateNotUsed(r, "bootstrap.html")
 
     @override_settings(
         CACHES={"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
@@ -173,9 +173,9 @@ class TestLogMessages(TestCase):
         self.client.force_login(u)
         r = self.client.get("/log-messages/")
         assert r.status_code == 200
-        self.assertTemplateUsed(r, 'log-messages.html')
-        self.assertTemplateUsed(r, 'base.html')
-        self.assertTemplateUsed(r, 'bootstrap.html')
+        self.assertTemplateUsed(r, "log-messages.html")
+        self.assertTemplateUsed(r, "base.html")
+        self.assertTemplateUsed(r, "bootstrap.html")
 
 
 class TestBlockMessages(TestCase):
@@ -184,9 +184,9 @@ class TestBlockMessages(TestCase):
         self.assertRedirects(
             r, "/login/twitter/?next=/block-messages/", fetch_redirect_response=False
         )
-        self.assertTemplateNotUsed(r, 'block-messages.html')
-        self.assertTemplateNotUsed(r, 'base.html')
-        self.assertTemplateNotUsed(r, 'bootstrap.html')
+        self.assertTemplateNotUsed(r, "block-messages.html")
+        self.assertTemplateNotUsed(r, "base.html")
+        self.assertTemplateNotUsed(r, "bootstrap.html")
 
     @override_settings(
         CACHES={"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
@@ -196,27 +196,27 @@ class TestBlockMessages(TestCase):
         self.client.force_login(u)
         r = self.client.get("/block-messages/")
         assert r.status_code == 200
-        self.assertTemplateUsed(r, 'block-messages.html')
-        self.assertTemplateUsed(r, 'base.html')
-        self.assertTemplateUsed(r, 'bootstrap.html')
+        self.assertTemplateUsed(r, "block-messages.html")
+        self.assertTemplateUsed(r, "base.html")
+        self.assertTemplateUsed(r, "bootstrap.html")
 
 
 class TestLogout(TestCase):
     def test_logout(self) -> None:
         r = self.client.get("/logout/")
         self.assertRedirects(r, "/", fetch_redirect_response=False)
-        self.assertTemplateNotUsed(r, 'logout.html')
-        self.assertTemplateNotUsed(r, 'base.html')
-        self.assertTemplateNotUsed(r, 'bootstrap.html')
+        self.assertTemplateNotUsed(r, "logout.html")
+        self.assertTemplateNotUsed(r, "base.html")
+        self.assertTemplateNotUsed(r, "bootstrap.html")
 
     def test_logout_with_user(self) -> None:
         u = _test_user()
         self.client.force_login(u)
         r = self.client.get("/logout/")
         self.assertRedirects(r, "/", fetch_redirect_response=False)
-        self.assertTemplateNotUsed(r, 'logout.html')
-        self.assertTemplateNotUsed(r, 'base.html')
-        self.assertTemplateNotUsed(r, 'bootstrap.html')
+        self.assertTemplateNotUsed(r, "logout.html")
+        self.assertTemplateNotUsed(r, "base.html")
+        self.assertTemplateNotUsed(r, "bootstrap.html")
 
 
 class TestDisconnect(TestCase):
@@ -225,9 +225,9 @@ class TestDisconnect(TestCase):
         self.assertRedirects(
             r, "/login/twitter/?next=/disconnect/", fetch_redirect_response=False
         )
-        self.assertTemplateNotUsed(r, 'disconnect.html')
-        self.assertTemplateNotUsed(r, 'base.html')
-        self.assertTemplateNotUsed(r, 'bootstrap.html')
+        self.assertTemplateNotUsed(r, "disconnect.html")
+        self.assertTemplateNotUsed(r, "base.html")
+        self.assertTemplateNotUsed(r, "bootstrap.html")
 
     @override_settings(
         CACHES={"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
@@ -237,18 +237,18 @@ class TestDisconnect(TestCase):
         self.client.force_login(u)
         r = self.client.get("/disconnect/")
         assert r.status_code == 200
-        self.assertTemplateUsed(r, 'disconnect.html')
-        self.assertTemplateUsed(r, 'base.html')
-        self.assertTemplateUsed(r, 'bootstrap.html')
+        self.assertTemplateUsed(r, "disconnect.html")
+        self.assertTemplateUsed(r, "base.html")
+        self.assertTemplateUsed(r, "bootstrap.html")
 
 
 class TestDisconnected(TestCase):
     def test_disconnected(self) -> None:
         r = self.client.get("/disconnected/")
         assert r.status_code == 200
-        self.assertTemplateUsed(r, 'disconnected.html')
-        self.assertTemplateUsed(r, 'base.html')
-        self.assertTemplateUsed(r, 'bootstrap.html')
+        self.assertTemplateUsed(r, "disconnected.html")
+        self.assertTemplateUsed(r, "base.html")
+        self.assertTemplateUsed(r, "bootstrap.html")
 
     @override_settings(
         CACHES={"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
@@ -258,9 +258,9 @@ class TestDisconnected(TestCase):
         self.client.force_login(u)
         r = self.client.get("/disconnected/")
         assert r.status_code == 200
-        self.assertTemplateUsed(r, 'disconnected.html')
-        self.assertTemplateUsed(r, 'base.html')
-        self.assertTemplateUsed(r, 'bootstrap.html')
+        self.assertTemplateUsed(r, "disconnected.html")
+        self.assertTemplateUsed(r, "base.html")
+        self.assertTemplateUsed(r, "bootstrap.html")
 
 
 class TestFollowing(TestCase):
@@ -269,9 +269,9 @@ class TestFollowing(TestCase):
         self.assertRedirects(
             r, "/login/twitter/?next=/following/", fetch_redirect_response=False
         )
-        self.assertTemplateNotUsed(r, 'following.html')
-        self.assertTemplateNotUsed(r, 'base.html')
-        self.assertTemplateNotUsed(r, 'bootstrap.html')
+        self.assertTemplateNotUsed(r, "following.html")
+        self.assertTemplateNotUsed(r, "base.html")
+        self.assertTemplateNotUsed(r, "bootstrap.html")
 
     @override_settings(
         CACHES={"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
@@ -281,9 +281,9 @@ class TestFollowing(TestCase):
         self.client.force_login(u)
         r = self.client.get("/following/")
         assert r.status_code == 200
-        self.assertTemplateUsed(r, 'following.html')
-        self.assertTemplateUsed(r, 'base.html')
-        self.assertTemplateUsed(r, 'bootstrap.html')
+        self.assertTemplateUsed(r, "following.html")
+        self.assertTemplateUsed(r, "base.html")
+        self.assertTemplateUsed(r, "bootstrap.html")
 
 
 class TestUpdateFollowing(TestCase):
@@ -292,9 +292,9 @@ class TestUpdateFollowing(TestCase):
         self.assertRedirects(
             r, "/login/twitter/?next=/update-following/", fetch_redirect_response=False
         )
-        self.assertTemplateNotUsed(r, 'update-following.html')
-        self.assertTemplateNotUsed(r, 'base.html')
-        self.assertTemplateNotUsed(r, 'bootstrap.html')
+        self.assertTemplateNotUsed(r, "update-following.html")
+        self.assertTemplateNotUsed(r, "base.html")
+        self.assertTemplateNotUsed(r, "bootstrap.html")
 
     @override_settings(
         CACHES={"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
@@ -304,9 +304,9 @@ class TestUpdateFollowing(TestCase):
         self.client.force_login(u)
         r = self.client.get("/update-following/")
         assert r.status_code == 200
-        self.assertTemplateUsed(r, 'update-following.html')
-        self.assertTemplateUsed(r, 'base.html')
-        self.assertTemplateUsed(r, 'bootstrap.html')
+        self.assertTemplateUsed(r, "update-following.html")
+        self.assertTemplateUsed(r, "base.html")
+        self.assertTemplateUsed(r, "bootstrap.html")
 
 
 def test_imports() -> None:

--- a/secateur/tests/test_views.py
+++ b/secateur/tests/test_views.py
@@ -257,10 +257,10 @@ class TestDisconnected(TestCase):
         u = _test_user()
         self.client.force_login(u)
         r = self.client.get("/disconnected/")
-        assert r.status_code == 200
-        self.assertTemplateUsed(r, "disconnected.html")
-        self.assertTemplateUsed(r, "base.html")
-        self.assertTemplateUsed(r, "bootstrap.html")
+        self.assertRedirects(r, "/disconnect/", fetch_redirect_response=False)
+        self.assertTemplateNotUsed(r, "disconnected.html")
+        self.assertTemplateNotUsed(r, "base.html")
+        self.assertTemplateNotUsed(r, "bootstrap.html")
 
 
 class TestFollowing(TestCase):

--- a/secateur/tests/test_views.py
+++ b/secateur/tests/test_views.py
@@ -7,6 +7,21 @@ class TestHome(TestCase):
     def test_home(self) -> None:
         r = self.client.get("/")
         assert r.status_code == 200
+        self.assertTemplateUsed(r, 'home.html')
+        self.assertTemplateUsed(r, 'base.html')
+        self.assertTemplateUsed(r, 'bootstrap.html')
+
+    @override_settings(
+        CACHES={"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
+    )
+    def test_home_with_user(self) -> None:
+        u = _test_user()
+        self.client.force_login(u)
+        r = self.client.get("/")
+        assert r.status_code == 200
+        self.assertTemplateUsed(r, 'home.html')
+        self.assertTemplateUsed(r, 'base.html')
+        self.assertTemplateUsed(r, 'bootstrap.html')
 
 
 class TestAdmin(TestCase):
@@ -15,6 +30,35 @@ class TestAdmin(TestCase):
         self.assertRedirects(
             r, "/admin/login/?next=/admin/", fetch_redirect_response=False
         )
+        self.assertTemplateNotUsed(r, 'admin/index.html')
+        self.assertTemplateNotUsed(r, 'admin/base_site.html')
+        self.assertTemplateNotUsed(r, 'admin/base.html')
+
+    @override_settings(
+        CACHES={"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
+    )
+    def test_admin_with_user(self) -> None:
+        r = self.client.get("/admin/")
+        self.assertRedirects(
+            r, "/admin/login/?next=/admin/", fetch_redirect_response=False
+        )
+        self.assertTemplateNotUsed(r, 'admin/index.html')
+        self.assertTemplateNotUsed(r, 'admin/base_site.html')
+        self.assertTemplateNotUsed(r, 'admin/base.html')
+
+    @override_settings(
+        CACHES={"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
+    )
+    def test_admin_with_admin_user(self) -> None:
+        u = _test_user()
+        u.is_staff = True
+        u.save()
+        self.client.force_login(u)
+        r = self.client.get("/admin/")
+        assert r.status_code == 200
+        self.assertTemplateUsed(r, 'admin/index.html')
+        self.assertTemplateUsed(r, 'admin/base_site.html')
+        self.assertTemplateUsed(r, 'admin/base.html')
 
 
 class TestBlock(TestCase):
@@ -23,6 +67,9 @@ class TestBlock(TestCase):
         self.assertRedirects(
             r, "/login/twitter/?next=/block/", fetch_redirect_response=False
         )
+        self.assertTemplateNotUsed(r, 'block.html')
+        self.assertTemplateNotUsed(r, 'base.html')
+        self.assertTemplateNotUsed(r, 'bootstrap.html')
 
     @override_settings(
         CACHES={"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
@@ -32,6 +79,9 @@ class TestBlock(TestCase):
         self.client.force_login(u)
         r = self.client.get("/block/")
         assert r.status_code == 200
+        self.assertTemplateUsed(r, 'block.html')
+        self.assertTemplateUsed(r, 'base.html')
+        self.assertTemplateUsed(r, 'bootstrap.html')
 
 
 @override_settings(
@@ -43,12 +93,18 @@ class TestBlocked(TestCase):
         self.assertRedirects(
             r, "/login/twitter/?next=/blocked/", fetch_redirect_response=False
         )
+        self.assertTemplateNotUsed(r, 'blocked.html')
+        self.assertTemplateNotUsed(r, 'base.html')
+        self.assertTemplateNotUsed(r, 'bootstrap.html')
 
     def test_blocked_with_user(self) -> None:
         u = _test_user()
         self.client.force_login(u)
         r = self.client.get("/blocked/")
         assert r.status_code == 200
+        self.assertTemplateUsed(r, 'blocked.html')
+        self.assertTemplateUsed(r, 'base.html')
+        self.assertTemplateUsed(r, 'bootstrap.html')
 
 
 @override_settings(
@@ -62,12 +118,18 @@ class TestUnblockEverybody(TestCase):
             "/login/twitter/?next=/unblock-everybody/",
             fetch_redirect_response=False,
         )
+        self.assertTemplateNotUsed(r, 'unblock-everybody.html')
+        self.assertTemplateNotUsed(r, 'base.html')
+        self.assertTemplateNotUsed(r, 'bootstrap.html')
 
     def test_unblock_everybody_with_user(self) -> None:
         u = _test_user()
         self.client.force_login(u)
         r = self.client.get("/unblock-everybody/")
         assert r.status_code == 200
+        self.assertTemplateUsed(r, 'unblock-everybody.html')
+        self.assertTemplateUsed(r, 'base.html')
+        self.assertTemplateUsed(r, 'bootstrap.html')
 
 
 class TestSearch(TestCase):
@@ -76,6 +138,9 @@ class TestSearch(TestCase):
         self.assertRedirects(
             r, "/login/twitter/?next=/search/", fetch_redirect_response=False
         )
+        self.assertTemplateNotUsed(r, 'search.html')
+        self.assertTemplateNotUsed(r, 'base.html')
+        self.assertTemplateNotUsed(r, 'bootstrap.html')
 
     @override_settings(
         CACHES={"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
@@ -85,6 +150,9 @@ class TestSearch(TestCase):
         self.client.force_login(u)
         r = self.client.get("/search/")
         assert r.status_code == 200
+        self.assertTemplateUsed(r, 'search.html')
+        self.assertTemplateUsed(r, 'base.html')
+        self.assertTemplateUsed(r, 'bootstrap.html')
 
 
 class TestLogMessages(TestCase):
@@ -93,6 +161,9 @@ class TestLogMessages(TestCase):
         self.assertRedirects(
             r, "/login/twitter/?next=/log-messages/", fetch_redirect_response=False
         )
+        self.assertTemplateNotUsed(r, 'log-messages.html')
+        self.assertTemplateNotUsed(r, 'base.html')
+        self.assertTemplateNotUsed(r, 'bootstrap.html')
 
     @override_settings(
         CACHES={"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
@@ -102,6 +173,9 @@ class TestLogMessages(TestCase):
         self.client.force_login(u)
         r = self.client.get("/log-messages/")
         assert r.status_code == 200
+        self.assertTemplateUsed(r, 'log-messages.html')
+        self.assertTemplateUsed(r, 'base.html')
+        self.assertTemplateUsed(r, 'bootstrap.html')
 
 
 class TestBlockMessages(TestCase):
@@ -110,6 +184,9 @@ class TestBlockMessages(TestCase):
         self.assertRedirects(
             r, "/login/twitter/?next=/block-messages/", fetch_redirect_response=False
         )
+        self.assertTemplateNotUsed(r, 'block-messages.html')
+        self.assertTemplateNotUsed(r, 'base.html')
+        self.assertTemplateNotUsed(r, 'bootstrap.html')
 
     @override_settings(
         CACHES={"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
@@ -119,18 +196,27 @@ class TestBlockMessages(TestCase):
         self.client.force_login(u)
         r = self.client.get("/block-messages/")
         assert r.status_code == 200
+        self.assertTemplateUsed(r, 'block-messages.html')
+        self.assertTemplateUsed(r, 'base.html')
+        self.assertTemplateUsed(r, 'bootstrap.html')
 
 
 class TestLogout(TestCase):
     def test_logout(self) -> None:
         r = self.client.get("/logout/")
         self.assertRedirects(r, "/", fetch_redirect_response=False)
+        self.assertTemplateNotUsed(r, 'logout.html')
+        self.assertTemplateNotUsed(r, 'base.html')
+        self.assertTemplateNotUsed(r, 'bootstrap.html')
 
     def test_logout_with_user(self) -> None:
         u = _test_user()
         self.client.force_login(u)
         r = self.client.get("/logout/")
         self.assertRedirects(r, "/", fetch_redirect_response=False)
+        self.assertTemplateNotUsed(r, 'logout.html')
+        self.assertTemplateNotUsed(r, 'base.html')
+        self.assertTemplateNotUsed(r, 'bootstrap.html')
 
 
 class TestDisconnect(TestCase):
@@ -139,6 +225,9 @@ class TestDisconnect(TestCase):
         self.assertRedirects(
             r, "/login/twitter/?next=/disconnect/", fetch_redirect_response=False
         )
+        self.assertTemplateNotUsed(r, 'disconnect.html')
+        self.assertTemplateNotUsed(r, 'base.html')
+        self.assertTemplateNotUsed(r, 'bootstrap.html')
 
     @override_settings(
         CACHES={"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
@@ -148,12 +237,18 @@ class TestDisconnect(TestCase):
         self.client.force_login(u)
         r = self.client.get("/disconnect/")
         assert r.status_code == 200
+        self.assertTemplateUsed(r, 'disconnect.html')
+        self.assertTemplateUsed(r, 'base.html')
+        self.assertTemplateUsed(r, 'bootstrap.html')
 
 
 class TestDisconnected(TestCase):
     def test_disconnected(self) -> None:
         r = self.client.get("/disconnected/")
         assert r.status_code == 200
+        self.assertTemplateUsed(r, 'disconnected.html')
+        self.assertTemplateUsed(r, 'base.html')
+        self.assertTemplateUsed(r, 'bootstrap.html')
 
     @override_settings(
         CACHES={"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
@@ -163,6 +258,9 @@ class TestDisconnected(TestCase):
         self.client.force_login(u)
         r = self.client.get("/disconnected/")
         assert r.status_code == 200
+        self.assertTemplateUsed(r, 'disconnected.html')
+        self.assertTemplateUsed(r, 'base.html')
+        self.assertTemplateUsed(r, 'bootstrap.html')
 
 
 class TestFollowing(TestCase):
@@ -171,6 +269,9 @@ class TestFollowing(TestCase):
         self.assertRedirects(
             r, "/login/twitter/?next=/following/", fetch_redirect_response=False
         )
+        self.assertTemplateNotUsed(r, 'following.html')
+        self.assertTemplateNotUsed(r, 'base.html')
+        self.assertTemplateNotUsed(r, 'bootstrap.html')
 
     @override_settings(
         CACHES={"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
@@ -180,6 +281,9 @@ class TestFollowing(TestCase):
         self.client.force_login(u)
         r = self.client.get("/following/")
         assert r.status_code == 200
+        self.assertTemplateUsed(r, 'following.html')
+        self.assertTemplateUsed(r, 'base.html')
+        self.assertTemplateUsed(r, 'bootstrap.html')
 
 
 class TestUpdateFollowing(TestCase):
@@ -188,6 +292,9 @@ class TestUpdateFollowing(TestCase):
         self.assertRedirects(
             r, "/login/twitter/?next=/update-following/", fetch_redirect_response=False
         )
+        self.assertTemplateNotUsed(r, 'update-following.html')
+        self.assertTemplateNotUsed(r, 'base.html')
+        self.assertTemplateNotUsed(r, 'bootstrap.html')
 
     @override_settings(
         CACHES={"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
@@ -197,6 +304,9 @@ class TestUpdateFollowing(TestCase):
         self.client.force_login(u)
         r = self.client.get("/update-following/")
         assert r.status_code == 200
+        self.assertTemplateUsed(r, 'update-following.html')
+        self.assertTemplateUsed(r, 'base.html')
+        self.assertTemplateUsed(r, 'bootstrap.html')
 
 
 def test_imports() -> None:

--- a/secateur/tests/test_views.py
+++ b/secateur/tests/test_views.py
@@ -44,6 +44,12 @@ class TestBlocked(TestCase):
             r, "/login/twitter/?next=/blocked/", fetch_redirect_response=False
         )
 
+    def test_blocked_with_user(self) -> None:
+        u = _test_user()
+        self.client.force_login(u)
+        r = self.client.get("/blocked/")
+        assert r.status_code == 200
+
 
 @override_settings(
     CACHES={"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
@@ -57,6 +63,12 @@ class TestUnblockEverybody(TestCase):
             fetch_redirect_response=False,
         )
 
+    def test_unblock_everybody_with_user(self) -> None:
+        u = _test_user()
+        self.client.force_login(u)
+        r = self.client.get("/unblock-everybody/")
+        assert r.status_code == 200
+
 
 class TestSearch(TestCase):
     def test_search(self) -> None:
@@ -64,6 +76,15 @@ class TestSearch(TestCase):
         self.assertRedirects(
             r, "/login/twitter/?next=/search/", fetch_redirect_response=False
         )
+
+    @override_settings(
+        CACHES={"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
+    )
+    def test_search_with_user(self) -> None:
+        u = _test_user()
+        self.client.force_login(u)
+        r = self.client.get("/search/")
+        assert r.status_code == 200
 
 
 class TestLogMessages(TestCase):
@@ -73,6 +94,15 @@ class TestLogMessages(TestCase):
             r, "/login/twitter/?next=/log-messages/", fetch_redirect_response=False
         )
 
+    @override_settings(
+        CACHES={"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
+    )
+    def test_log_messages_with_user(self) -> None:
+        u = _test_user()
+        self.client.force_login(u)
+        r = self.client.get("/log-messages/")
+        assert r.status_code == 200
+
 
 class TestBlockMessages(TestCase):
     def test_block_messages(self) -> None:
@@ -81,9 +111,24 @@ class TestBlockMessages(TestCase):
             r, "/login/twitter/?next=/block-messages/", fetch_redirect_response=False
         )
 
+    @override_settings(
+        CACHES={"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
+    )
+    def test_block_messages_with_user(self) -> None:
+        u = _test_user()
+        self.client.force_login(u)
+        r = self.client.get("/block-messages/")
+        assert r.status_code == 200
+
 
 class TestLogout(TestCase):
     def test_logout(self) -> None:
+        r = self.client.get("/logout/")
+        self.assertRedirects(r, "/", fetch_redirect_response=False)
+
+    def test_logout_with_user(self) -> None:
+        u = _test_user()
+        self.client.force_login(u)
         r = self.client.get("/logout/")
         self.assertRedirects(r, "/", fetch_redirect_response=False)
 
@@ -95,9 +140,27 @@ class TestDisconnect(TestCase):
             r, "/login/twitter/?next=/disconnect/", fetch_redirect_response=False
         )
 
+    @override_settings(
+        CACHES={"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
+    )
+    def test_disconnect_with_user(self) -> None:
+        u = _test_user()
+        self.client.force_login(u)
+        r = self.client.get("/disconnect/")
+        assert r.status_code == 200
+
 
 class TestDisconnected(TestCase):
     def test_disconnected(self) -> None:
+        r = self.client.get("/disconnected/")
+        assert r.status_code == 200
+
+    @override_settings(
+        CACHES={"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
+    )
+    def test_disconnected_with_user(self) -> None:
+        u = _test_user()
+        self.client.force_login(u)
         r = self.client.get("/disconnected/")
         assert r.status_code == 200
 
@@ -109,6 +172,15 @@ class TestFollowing(TestCase):
             r, "/login/twitter/?next=/following/", fetch_redirect_response=False
         )
 
+    @override_settings(
+        CACHES={"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
+    )
+    def test_following_with_user(self) -> None:
+        u = _test_user()
+        self.client.force_login(u)
+        r = self.client.get("/following/")
+        assert r.status_code == 200
+
 
 class TestUpdateFollowing(TestCase):
     def test_update_following(self) -> None:
@@ -116,6 +188,15 @@ class TestUpdateFollowing(TestCase):
         self.assertRedirects(
             r, "/login/twitter/?next=/update-following/", fetch_redirect_response=False
         )
+
+    @override_settings(
+        CACHES={"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
+    )
+    def test_update_following_with_user(self) -> None:
+        u = _test_user()
+        self.client.force_login(u)
+        r = self.client.get("/update-following/")
+        assert r.status_code == 200
 
 
 def test_imports() -> None:

--- a/secateur/views.py
+++ b/secateur/views.py
@@ -318,6 +318,13 @@ class Disconnect(LoginRequiredMixin, FormView):
 class Disconnected(TemplateView):
     template_name = "disconnected.html"
 
+    def get(
+        self, request: django.http.HttpRequest, *args: Any, **kwargs: Any
+    ) -> django.http.HttpResponse:
+        if request.user.is_authenticated:
+            return django.http.HttpResponseRedirect("/disconnect/")
+        return super().get(request, *args, **kwargs)
+
 
 class Following(LoginRequiredMixin, ListView):
     template_name = "following.html"


### PR DESCRIPTION
Builds on #50

/disconnected/ can be visited while logged in and presents a message that is incorrect while in that state.

This change causes that situation to result in a redirect to /disconnect/ instead.