### PR TITLE
build: Run build workflow on PRs.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 name: Build Secateur
-on: [push]
+on: [push, pull_request]
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
It would be useful to have the build job run on PRs.

Some notes on this:
* No secrets are passed to workflows run from forks, except for the GITHUB_TOKEN, which is provided with read-only privileges. This prevents secret leakage. (https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflows-in-forked-repositories-1)
* A maintainer with write permission will need to approve runs from first-time contributors. (https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks)